### PR TITLE
Fixed SERVER env definition

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -2,7 +2,7 @@
 
 mkdir -p "$MOUNTPOINT"
 
-if [$SERVER == ""]; then
+if [ "$SERVER" = "" ]; then
 rpc.statd & rpcbind -f & echo "docker NFS client with rpcbind ENABLED... if you wish to mount the mountpoint in this container USE THE FOLLOWING SYNTAX instead:
 $ docker run -itd --privileged=true --net=host -v vol:/mnt/nfs-1:shared -e SERVER= X.X.X.X -e SHARE=shared_path d3fk/nfs-client" & more
 else


### PR DESCRIPTION
Since the env is not wrapped in double quotes, bash breaks.  
So just wrapping in double quotes to do a proper if match.